### PR TITLE
Fix JSON-RPC notifications handling

### DIFF
--- a/.changeset/eleven-doors-build.md
+++ b/.changeset/eleven-doors-build.md
@@ -1,0 +1,5 @@
+---
+"mcp-mcp-mcp": patch
+---
+
+This fixes notification handling in the JSON-RPC parsing. We'd previously break - no longer. Also refactors the code to make it more readable.

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -22,5 +22,14 @@
         "recommended": true
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["packages/core/**/*.test.ts"],
+      "linter": {
+        "rules": { "suspicious": { "noExplicitAny": "warn" } }
+      }
+    }
+  ],
+  "files": { "includes": ["**", "!**/dist"] }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,8 @@ export type {
   InitializeResult,
   JsonRpcError,
   JsonRpcId,
+  JsonRpcMessage,
+  JsonRpcNotification,
   JsonRpcReq,
   JsonRpcRes,
   MCPServerContext as Ctx,
@@ -18,6 +20,8 @@ export type {
 export {
   createJsonRpcError,
   createJsonRpcResponse,
-  isValidJsonRpcRequest,
+  isJsonRpcNotification,
+  isJsonRpcRequest,
+  isValidJsonRpcMessage,
   JSON_RPC_ERROR_CODES,
 } from "./types.js";

--- a/packages/core/tests/integration/e2e.test.ts
+++ b/packages/core/tests/integration/e2e.test.ts
@@ -40,6 +40,69 @@ function createTestHandler() {
   return transport.bind(mcp);
 }
 
+// Create a test handler with middleware for response testing
+function createTestHandlerWithMiddleware() {
+  const mcp = new McpServer({
+    name: "test-server",
+    version: "1.0.0",
+  });
+
+  // Track middleware execution order and response access
+  const middlewareLog: string[] = [];
+
+  // First middleware - logs before and after
+  mcp.use(async (ctx, next) => {
+    middlewareLog.push("middleware1-before");
+    expect(ctx.response).toBe(null); // Response should be null before next()
+
+    await next();
+
+    middlewareLog.push("middleware1-after");
+    expect(ctx.response).toBeTruthy(); // Response should be set after next()
+    expect(ctx.response?.jsonrpc).toBe("2.0");
+
+    // Middleware can inspect the tool result
+    if (ctx.response?.result && typeof ctx.response.result === "object") {
+      const result = ctx.response.result as {
+        content: Array<{ type: string; text: string }>;
+      };
+      if (result.content?.[0]?.text === "Hello World") {
+        middlewareLog.push("middleware1-saw-echo-result");
+      }
+    }
+  });
+
+  // Second middleware - also logs and can modify state
+  mcp.use(async (ctx, next) => {
+    middlewareLog.push("middleware2-before");
+    ctx.state.middlewareData = "test-data";
+
+    await next();
+
+    middlewareLog.push("middleware2-after");
+    expect(ctx.response).toBeTruthy();
+  });
+
+  mcp.tool("echo", {
+    description: "Echoes the input message",
+    handler: (args: { message: string }) => {
+      middlewareLog.push("handler-executed");
+      return {
+        content: [{ type: "text", text: args.message }],
+      };
+    },
+  });
+
+  const transport = new StreamableHttpTransport();
+  const handler = transport.bind(mcp);
+
+  // Return both handler and log accessor
+  return {
+    handler,
+    getMiddlewareLog: () => middlewareLog,
+  };
+}
+
 describe("E2E MCP Integration", () => {
   let handler: (request: Request) => Promise<Response>;
 
@@ -150,6 +213,77 @@ describe("E2E MCP Integration", () => {
       const result = (await response.json()) as JsonRpcResponse;
       expect(result.error).toBeDefined();
       expect(result.error?.code).toBe(-32600);
+    });
+  });
+
+  describe("Middleware response access", () => {
+    it("should allow middleware to access response after await next()", async () => {
+      // Use the middleware-enabled handler
+      const { handler: handlerWithMiddleware, getMiddlewareLog } =
+        createTestHandlerWithMiddleware();
+
+      // First initialize the server
+      const initRequest = new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "MCP-Protocol-Version": "2025-06-18",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "init",
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            clientInfo: { name: "test-client", version: "1.0.0" },
+          },
+        }),
+      });
+
+      await handlerWithMiddleware(initRequest);
+
+      // Clear the log after initialization to focus on tool call middleware
+      getMiddlewareLog().length = 0;
+
+      // Now call a tool to test middleware response access
+      const toolRequest = new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "MCP-Protocol-Version": "2025-06-18",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "tool-call",
+          method: "tools/call",
+          params: {
+            name: "echo",
+            arguments: { message: "Hello World" },
+          },
+        }),
+      });
+
+      const response = await handlerWithMiddleware(toolRequest);
+      expect(response.ok).toBe(true);
+
+      const result = (await response.json()) as JsonRpcResponse;
+      expect(result.error).toBeUndefined();
+      expect(result.result).toEqual({
+        content: [{ type: "text", text: "Hello World" }],
+      });
+
+      // Get the middleware log to verify execution order and response access
+      const middlewareLog = getMiddlewareLog();
+
+      // Verify execution order: middleware runs in order, handler executes, then middleware completes in reverse order
+      expect(middlewareLog).toEqual([
+        "middleware1-before",
+        "middleware2-before",
+        "handler-executed",
+        "middleware2-after",
+        "middleware1-after",
+        "middleware1-saw-echo-result", // This proves middleware could access and inspect the response
+      ]);
     });
   });
 });

--- a/packages/core/tests/integration/notification.test.ts
+++ b/packages/core/tests/integration/notification.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { McpServer } from "../../src/core.js";
+import { StreamableHttpTransport } from "../../src/transport-http.js";
+
+describe("JSON-RPC Notification Handling", () => {
+  let server: McpServer;
+  let transport: StreamableHttpTransport;
+  let httpHandler: (request: Request) => Promise<Response>;
+
+  beforeEach(() => {
+    server = new McpServer({ name: "test", version: "1.0.0" });
+    transport = new StreamableHttpTransport();
+    httpHandler = transport.bind(server);
+  });
+
+  it("should handle notifications/initialized with HTTP 204 response", async () => {
+    const notificationRequest = new Request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-06-18",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+      }),
+    });
+
+    const response = await httpHandler(notificationRequest);
+
+    expect(response.status).toBe(204);
+    expect(response.body).toBeNull();
+
+    const text = await response.text();
+    expect(text).toBe("");
+  });
+
+  it("should handle regular requests with HTTP 200 and JSON response", async () => {
+    const requestRequest = new Request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-06-18",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "1",
+        method: "ping",
+      }),
+    });
+
+    const response = await httpHandler(requestRequest);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+
+    const json = await response.json();
+    expect(json).toEqual({
+      jsonrpc: "2.0",
+      id: "1",
+      result: {},
+    });
+  });
+
+  it("should handle notifications/cancelled without response", async () => {
+    const notificationRequest = new Request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-06-18",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "notifications/cancelled",
+        params: {
+          requestId: "test-request",
+          reason: "User cancelled",
+        },
+      }),
+    });
+
+    const response = await httpHandler(notificationRequest);
+
+    expect(response.status).toBe(204);
+    expect(response.body).toBeNull();
+  });
+
+  it("should handle unknown notification method gracefully", async () => {
+    const notificationRequest = new Request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-06-18",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "notifications/unknown",
+        params: {
+          someData: "test",
+        },
+      }),
+    });
+
+    const response = await httpHandler(notificationRequest);
+
+    // Should still return 204 even for unknown notification methods
+    expect(response.status).toBe(204);
+    expect(response.body).toBeNull();
+  });
+
+  it("should handle mixed request and notification in sequence", async () => {
+    // First send a request
+    const requestRequest = new Request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-06-18",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "1",
+        method: "ping",
+      }),
+    });
+
+    const requestResponse = await httpHandler(requestRequest);
+    expect(requestResponse.status).toBe(200);
+
+    const requestJson = await requestResponse.json();
+    expect(requestJson.id).toBe("1");
+    expect(requestJson.result).toEqual({});
+
+    // Then send a notification
+    const notificationRequest = new Request("http://localhost/mcp", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": "2025-06-18",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "notifications/initialized",
+      }),
+    });
+
+    const notificationResponse = await httpHandler(notificationRequest);
+    expect(notificationResponse.status).toBe(204);
+    expect(notificationResponse.body).toBeNull();
+  });
+});

--- a/playground/.mcp.json
+++ b/playground/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playground": {
+      "type": "http",
+      "url": "http://localhost:3001/mcp"
+    }
+  }
+}

--- a/playground/minimal-server.ts
+++ b/playground/minimal-server.ts
@@ -50,9 +50,7 @@ mcp.tool("add", {
 });
 
 // Create HTTP transport
-const transport = new StreamableHttpTransport({
-  protocol: { version: "2025-06-18" },
-});
+const transport = new StreamableHttpTransport();
 const httpHandler = transport.bind(mcp);
 
 // Create Hono app


### PR DESCRIPTION
Earlier version of this was breaking because we didn't handle the JSON-RPC notifications per the MCP spec. Now we do.
