### PR TITLE
create-mcp-lite: Showed deployed mcp server url in final message

### DIFF
--- a/.changeset/quiet-pumas-sell.md
+++ b/.changeset/quiet-pumas-sell.md
@@ -1,0 +1,5 @@
+---
+"create-mcp-lite": patch
+---
+
+Try to print a deploy url to the mcp server after deploying

--- a/packages/create-mcp-lite/package.json
+++ b/packages/create-mcp-lite/package.json
@@ -7,6 +7,7 @@
     "build": "bun run scripts/build.ts",
     "build:types": "tsc --project tsconfig.build.json --outDir dist/types --rootDir src",
     "dev": "bun run scripts/build.ts && node dist/index.js",
+    "dev:local": "bun run scripts/build.ts && FIBERPLANE_API_URL=http://localhost:7676 node dist/index.js",
     "dev:target": "bun run scripts/build.ts && node dist/index.js test-name",
     "test": "bun test",
     "typecheck": "tsc --noEmit",

--- a/packages/create-mcp-lite/src/context.ts
+++ b/packages/create-mcp-lite/src/context.ts
@@ -11,6 +11,7 @@ export interface Context {
   aiAssistant?: AIAssistant;
   flags: Flags;
   fpMcpServerEnabled: boolean;
+  deploymentUrl?: string;
 }
 
 /**

--- a/packages/create-mcp-lite/src/index.ts
+++ b/packages/create-mcp-lite/src/index.ts
@@ -82,7 +82,11 @@ open https://docs.fiberplane.com
 
 ${
   context.flags.includes("deploy-fiberplane")
-    ? `\n${pico.green("✓")} Fiberplane deployment is configured and ready!`
+    ? `\n${pico.green("✓")} Fiberplane deployment is configured and ready!${
+        context.deploymentUrl
+          ? `\n${pico.cyan("🔗")} Your deployment: ${pico.bold(pico.cyan(context.deploymentUrl))}`
+          : ""
+      }`
     : ""
 }
 `);


### PR DESCRIPTION
final small dx tweak to create-mcp-lite: read the deployed app's url from the .fiberplane config and show that in the terminal output 