### PR TITLE
Add docstring for schema adapter

### DIFF
--- a/.changeset/yellow-animals-find.md
+++ b/.changeset/yellow-animals-find.md
@@ -1,0 +1,5 @@
+---
+"mcp-lite": patch
+---
+
+Add a docstring to the schemaAdapter option for McpServer, to clarify its usage in practice

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -92,6 +92,22 @@ function errorToResponse(
 export interface McpServerOptions {
   name: string;
   version: string;
+  /**
+   * A function that converts a StandardSchema to a JSON Schema
+   *
+   * In practice, you will need to coerce the `schema` parameter of this function to the correct type for the library you are using,
+   * in order to pass it to a helper that handles converting to JSON Schema.
+   *
+   * @example Using Zod
+   * ```typescript
+   * import { z } from "zod";
+   *
+   * const server = new McpServer({
+   *   // ...
+   *   schemaAdapter: (schema) => z.toJSONSchema(schema as z.ZodType),
+   * });
+   * ```
+   */
   schemaAdapter?: SchemaAdapter;
 }
 


### PR DESCRIPTION
Added a docstring for schemaAdapter so it pops up in my IDE:

<img width="1022" height="478" alt="image" src="https://github.com/user-attachments/assets/648a73fc-b89e-442f-b020-2f2c2202c5cc" />
