### PR TITLE
Add support for `authInfo` on context

### DIFF
--- a/examples/auth-clerk/src/auth/middleware.ts
+++ b/examples/auth-clerk/src/auth/middleware.ts
@@ -26,6 +26,8 @@ export const mcpAuthMiddleware = createMiddleware<
     const resourceMetadataUrl = getPRMUrl(c.req.raw);
     c.header(
       "WWW-Authenticate",
+      // NOTE - The mcp sdk adds `error` and `error_description` to this header as well, depending on the error
+      //        see: https://github.com/modelcontextprotocol/typescript-sdk/blob/b28c297184cb0cb64611a3357d6438dd1b0824c6/src/server/auth/middleware/bearerAuth.ts#L76C1-L95C8
       `Bearer resource_metadata="${resourceMetadataUrl}"`,
     );
     return c.json({ error: "Unauthorized" }, 401);

--- a/examples/auth-clerk/src/index.ts
+++ b/examples/auth-clerk/src/index.ts
@@ -16,7 +16,8 @@ app.route("/", authRoutes);
 
 // Add MCP endpoint
 app.all("/mcp", mcpAuthMiddleware, async (c) => {
-  const response = await mcpHttpHandler(c.req.raw);
+  const authInfo = c.get("auth");
+  const response = await mcpHttpHandler(c.req.raw, { authInfo });
   return response;
 });
 

--- a/packages/core/src/auth.ts
+++ b/packages/core/src/auth.ts
@@ -1,0 +1,12 @@
+/**
+ * Similar type to the @modelcontextprotocol/sdk AuthInfo type.
+ * Allows for cross-compatibility with the @modelcontextprotocol/sdk.
+ */
+export type AuthInfo = {
+  token: string;
+  scopes: string[];
+  /** Token expiry in seconds since epoch */
+  expiresAt?: number;
+  /** Additional provider-specific data */
+  extra?: Record<string, unknown>;
+};

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -1,3 +1,4 @@
+import type { AuthInfo } from "./auth.js";
 import { SUPPORTED_MCP_PROTOCOL_VERSION } from "./constants.js";
 import type {
   JsonRpcId,
@@ -13,6 +14,7 @@ export interface CreateContextOptions {
   sessionId?: string;
   progressToken?: ProgressToken;
   progressSender?: (update: ProgressUpdate) => Promise<void> | void;
+  authInfo?: AuthInfo;
 }
 
 /**
@@ -44,6 +46,7 @@ export function createContext(
 
   const context: MCPServerContext = {
     request: message,
+    authInfo: options.authInfo,
     requestId,
     response: null,
     env: {},

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -730,6 +730,7 @@ export class McpServer {
       sessionId,
       progressToken,
       progressSender,
+      authInfo: contextOptions.authInfo,
     });
 
     const method = (message as JsonRpcMessage).method;

--- a/packages/core/src/transport-http.ts
+++ b/packages/core/src/transport-http.ts
@@ -1,3 +1,4 @@
+import type { AuthInfo } from "./auth.js";
 import {
   JSON_RPC_VERSION,
   MCP_LAST_EVENT_ID_HEADER,
@@ -66,7 +67,12 @@ export class StreamableHttpTransport {
     this.allowedHosts = options.allowedHosts;
   }
 
-  bind(server: McpServer): (request: Request) => Promise<Response> {
+  bind(
+    server: McpServer,
+  ): (
+    request: Request,
+    options?: { authInfo?: AuthInfo },
+  ) => Promise<Response> {
     this.server = server;
 
     server._setNotificationSender(async (sessionId, notification, options) => {
@@ -132,7 +138,10 @@ export class StreamableHttpTransport {
     return this.handleRequest.bind(this);
   }
 
-  private async handleRequest(request: Request): Promise<Response> {
+  private async handleRequest(
+    request: Request,
+    options?: { authInfo?: AuthInfo },
+  ): Promise<Response> {
     if (!this.server) {
       throw new Error("Transport not bound to a server");
     }
@@ -176,7 +185,10 @@ export class StreamableHttpTransport {
     }
   }
 
-  private async handlePost(request: Request): Promise<Response> {
+  private async handlePost(
+    request: Request,
+    options?: { authInfo?: AuthInfo },
+  ): Promise<Response> {
     try {
       const body = await request.text();
       const jsonRpcMessage = parseJsonRpc(body);
@@ -252,6 +264,7 @@ export class StreamableHttpTransport {
 
       const response = await this.server?._dispatch(jsonRpcMessage, {
         sessionId: sessionId || undefined,
+        authInfo: options?.authInfo,
       });
 
       if (isInitializeRequest && response) {

--- a/packages/core/src/transport-http.ts
+++ b/packages/core/src/transport-http.ts
@@ -162,7 +162,7 @@ export class StreamableHttpTransport {
 
     switch (request.method) {
       case "POST":
-        return this.handlePost(request);
+        return this.handlePost(request, { authInfo: options?.authInfo });
       case "GET":
         return this.handleGet(request);
       case "DELETE":
@@ -259,6 +259,7 @@ export class StreamableHttpTransport {
           jsonRpcRequest: jsonRpcMessage,
           sessionId,
           isNotification,
+          authInfo: options?.authInfo,
         });
       }
 
@@ -433,8 +434,10 @@ export class StreamableHttpTransport {
     jsonRpcRequest: unknown;
     sessionId: string | null;
     isNotification: boolean;
+    authInfo?: AuthInfo;
   }): Promise<Response> {
-    const { request, jsonRpcRequest, sessionId, isNotification } = args;
+    const { request, jsonRpcRequest, sessionId, isNotification, authInfo } =
+      args;
 
     if (isNotification) {
       return new Response(
@@ -472,6 +475,7 @@ export class StreamableHttpTransport {
     Promise.resolve(
       this.server?._dispatch(jsonRpcRequest as JsonRpcReq, {
         sessionId: sessionId || undefined,
+        authInfo,
       }),
     )
       .then(async (rpcResponse) => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,5 @@
 import type { StandardSchemaV1 } from "@standard-schema/spec";
+import type { AuthInfo } from "./auth.js";
 import { JSON_RPC_VERSION } from "./constants.js";
 import type { UriMatcher } from "./uri-template.js";
 import {
@@ -94,6 +95,10 @@ export interface MCPServerContext {
   response: JsonRpcRes | null;
   env: Record<string, unknown>;
   state: Record<string, unknown>;
+  /**
+   * Info on the authenticated user, if any
+   */
+  authInfo?: AuthInfo;
   session?: { id: string; protocolVersion: string };
   progressToken?: ProgressToken;
   validate<T>(validator: unknown, input: unknown): T;

--- a/packages/core/tests/integration/auth-info.test.ts
+++ b/packages/core/tests/integration/auth-info.test.ts
@@ -15,6 +15,29 @@ interface JsonRpcResponse {
   };
 }
 
+// Reusable initialize request payload
+const INIT_REQUEST_BODY = {
+  jsonrpc: "2.0",
+  id: "init",
+  method: "initialize",
+  params: {
+    protocolVersion: "2025-06-18",
+    clientInfo: { name: "test-client", version: "1.0.0" },
+  },
+} as const;
+
+// Utility function to create initialize request
+function createInitializationRequest(): Request {
+  return new Request("http://localhost/mcp", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "MCP-Protocol-Version": "2025-06-18",
+    },
+    body: JSON.stringify(INIT_REQUEST_BODY),
+  });
+}
+
 describe("AuthInfo Integration", () => {
   let server: McpServer;
   let transport: StreamableHttpTransport;
@@ -53,22 +76,7 @@ describe("AuthInfo Integration", () => {
       const handler = transport.bind(server);
 
       // Initialize the server first
-      const initRequest = new Request("http://localhost/mcp", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "MCP-Protocol-Version": "2025-06-18",
-        },
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          id: "init",
-          method: "initialize",
-          params: {
-            protocolVersion: "2025-06-18",
-            clientInfo: { name: "test-client", version: "1.0.0" },
-          },
-        }),
-      });
+      const initRequest = createInitializationRequest();
 
       await handler(initRequest, { authInfo: mockAuthInfo });
 
@@ -120,22 +128,7 @@ describe("AuthInfo Integration", () => {
       const handler = transport.bind(server);
 
       // Initialize without authInfo
-      const initRequest = new Request("http://localhost/mcp", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "MCP-Protocol-Version": "2025-06-18",
-        },
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          id: "init",
-          method: "initialize",
-          params: {
-            protocolVersion: "2025-06-18",
-            clientInfo: { name: "test-client", version: "1.0.0" },
-          },
-        }),
-      });
+      const initRequest = createInitializationRequest();
 
       await handler(initRequest);
 
@@ -206,22 +199,7 @@ describe("AuthInfo Integration", () => {
       const handler = transport.bind(server);
 
       // Initialize with authInfo
-      const initRequest = new Request("http://localhost/mcp", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "MCP-Protocol-Version": "2025-06-18",
-        },
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          id: "init",
-          method: "initialize",
-          params: {
-            protocolVersion: "2025-06-18",
-            clientInfo: { name: "test-client", version: "1.0.0" },
-          },
-        }),
-      });
+      const initRequest = createInitializationRequest();
 
       await handler(initRequest, { authInfo: mockAuthInfo });
 
@@ -296,22 +274,7 @@ describe("AuthInfo Integration", () => {
       const handler = transport.bind(server);
 
       // Initialize without authInfo
-      const initRequest = new Request("http://localhost/mcp", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "MCP-Protocol-Version": "2025-06-18",
-        },
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          id: "init",
-          method: "initialize",
-          params: {
-            protocolVersion: "2025-06-18",
-            clientInfo: { name: "test-client", version: "1.0.0" },
-          },
-        }),
-      });
+      const initRequest = createInitializationRequest();
 
       await handler(initRequest);
 

--- a/packages/core/tests/integration/auth-info.test.ts
+++ b/packages/core/tests/integration/auth-info.test.ts
@@ -1,0 +1,532 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import type { AuthInfo } from "../../src/auth.js";
+import { McpServer, StreamableHttpTransport } from "../../src/index.js";
+import type { MCPServerContext } from "../../src/types.js";
+
+// Type for JSON-RPC response
+interface JsonRpcResponse {
+  jsonrpc: string;
+  id: string | number | null;
+  result?: unknown;
+  error?: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+}
+
+describe("AuthInfo Integration", () => {
+  let server: McpServer;
+  let transport: StreamableHttpTransport;
+
+  const mockAuthInfo: AuthInfo = {
+    token: "test-token-123",
+    scopes: ["read", "write"],
+    expiresAt: Date.now() / 1000 + 3600, // 1 hour from now
+    extra: { userId: "user-123", provider: "test" },
+  };
+
+  beforeEach(() => {
+    server = new McpServer({
+      name: "test-server",
+      version: "1.0.0",
+    });
+    transport = new StreamableHttpTransport();
+  });
+
+  describe("Tool handler authInfo access", () => {
+    it("should pass authInfo to tool handlers when provided", async () => {
+      let capturedAuthInfo: AuthInfo | undefined;
+      let capturedContext: MCPServerContext | undefined;
+
+      server.tool("auth-test", {
+        description: "Test tool that captures authInfo",
+        handler: (_args, ctx) => {
+          capturedAuthInfo = ctx.authInfo;
+          capturedContext = ctx;
+          return {
+            content: [{ type: "text", text: "auth-test-response" }],
+          };
+        },
+      });
+
+      const handler = transport.bind(server);
+
+      // Initialize the server first
+      const initRequest = new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "MCP-Protocol-Version": "2025-06-18",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "init",
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            clientInfo: { name: "test-client", version: "1.0.0" },
+          },
+        }),
+      });
+
+      await handler(initRequest, { authInfo: mockAuthInfo });
+
+      // Call the tool with authInfo
+      const toolRequest = new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "MCP-Protocol-Version": "2025-06-18",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "tool-call",
+          method: "tools/call",
+          params: {
+            name: "auth-test",
+            arguments: {},
+          },
+        }),
+      });
+
+      const response = await handler(toolRequest, { authInfo: mockAuthInfo });
+      expect(response.ok).toBe(true);
+
+      const result = (await response.json()) as JsonRpcResponse;
+      expect(result.error).toBeUndefined();
+      expect(result.result).toEqual({
+        content: [{ type: "text", text: "auth-test-response" }],
+      });
+
+      // Verify authInfo was passed correctly
+      expect(capturedAuthInfo).toEqual(mockAuthInfo);
+      expect(capturedContext?.authInfo).toEqual(mockAuthInfo);
+    });
+
+    it("should work normally when authInfo is not provided", async () => {
+      let capturedAuthInfo: AuthInfo | undefined;
+
+      server.tool("no-auth-test", {
+        description: "Test tool without authInfo",
+        handler: (_args, ctx) => {
+          capturedAuthInfo = ctx.authInfo;
+          return {
+            content: [{ type: "text", text: "no-auth-response" }],
+          };
+        },
+      });
+
+      const handler = transport.bind(server);
+
+      // Initialize without authInfo
+      const initRequest = new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "MCP-Protocol-Version": "2025-06-18",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "init",
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            clientInfo: { name: "test-client", version: "1.0.0" },
+          },
+        }),
+      });
+
+      await handler(initRequest);
+
+      // Call tool without authInfo
+      const toolRequest = new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "MCP-Protocol-Version": "2025-06-18",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "tool-call",
+          method: "tools/call",
+          params: {
+            name: "no-auth-test",
+            arguments: {},
+          },
+        }),
+      });
+
+      const response = await handler(toolRequest);
+      expect(response.ok).toBe(true);
+
+      const result = (await response.json()) as JsonRpcResponse;
+      expect(result.error).toBeUndefined();
+      expect(result.result).toEqual({
+        content: [{ type: "text", text: "no-auth-response" }],
+      });
+
+      // Verify authInfo is undefined when not provided
+      expect(capturedAuthInfo).toBeUndefined();
+    });
+  });
+
+  describe("Middleware authInfo access", () => {
+    it("should pass authInfo to middleware when provided", async () => {
+      const middlewareLog: Array<{
+        phase: string;
+        authInfo?: AuthInfo;
+        hasAuthInfo: boolean;
+      }> = [];
+
+      // Add middleware that captures authInfo
+      server.use(async (ctx, next) => {
+        middlewareLog.push({
+          phase: "before",
+          authInfo: ctx.authInfo,
+          hasAuthInfo: !!ctx.authInfo,
+        });
+
+        await next();
+
+        middlewareLog.push({
+          phase: "after",
+          authInfo: ctx.authInfo,
+          hasAuthInfo: !!ctx.authInfo,
+        });
+      });
+
+      server.tool("middleware-test", {
+        description: "Test tool for middleware authInfo",
+        handler: () => ({
+          content: [{ type: "text", text: "middleware-test-response" }],
+        }),
+      });
+
+      const handler = transport.bind(server);
+
+      // Initialize with authInfo
+      const initRequest = new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "MCP-Protocol-Version": "2025-06-18",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "init",
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            clientInfo: { name: "test-client", version: "1.0.0" },
+          },
+        }),
+      });
+
+      await handler(initRequest, { authInfo: mockAuthInfo });
+
+      // Clear log after initialization
+      middlewareLog.length = 0;
+
+      // Call tool with authInfo
+      const toolRequest = new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "MCP-Protocol-Version": "2025-06-18",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "tool-call",
+          method: "tools/call",
+          params: {
+            name: "middleware-test",
+            arguments: {},
+          },
+        }),
+      });
+
+      const response = await handler(toolRequest, { authInfo: mockAuthInfo });
+      expect(response.ok).toBe(true);
+
+      // Verify middleware received authInfo
+      expect(middlewareLog).toHaveLength(2);
+      expect(middlewareLog[0]).toEqual({
+        phase: "before",
+        authInfo: mockAuthInfo,
+        hasAuthInfo: true,
+      });
+      expect(middlewareLog[1]).toEqual({
+        phase: "after",
+        authInfo: mockAuthInfo,
+        hasAuthInfo: true,
+      });
+    });
+
+    it("should work in middleware when authInfo is not provided", async () => {
+      const middlewareLog: Array<{
+        phase: string;
+        authInfo?: AuthInfo;
+        hasAuthInfo: boolean;
+      }> = [];
+
+      server.use(async (ctx, next) => {
+        middlewareLog.push({
+          phase: "before",
+          authInfo: ctx.authInfo,
+          hasAuthInfo: !!ctx.authInfo,
+        });
+
+        await next();
+
+        middlewareLog.push({
+          phase: "after",
+          authInfo: ctx.authInfo,
+          hasAuthInfo: !!ctx.authInfo,
+        });
+      });
+
+      server.tool("no-middleware-auth-test", {
+        description: "Test tool for middleware without authInfo",
+        handler: () => ({
+          content: [{ type: "text", text: "no-middleware-auth-response" }],
+        }),
+      });
+
+      const handler = transport.bind(server);
+
+      // Initialize without authInfo
+      const initRequest = new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "MCP-Protocol-Version": "2025-06-18",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "init",
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-06-18",
+            clientInfo: { name: "test-client", version: "1.0.0" },
+          },
+        }),
+      });
+
+      await handler(initRequest);
+
+      // Clear log after initialization
+      middlewareLog.length = 0;
+
+      // Call tool without authInfo
+      const toolRequest = new Request("http://localhost/mcp", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "MCP-Protocol-Version": "2025-06-18",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: "tool-call",
+          method: "tools/call",
+          params: {
+            name: "no-middleware-auth-test",
+            arguments: {},
+          },
+        }),
+      });
+
+      const response = await handler(toolRequest);
+      expect(response.ok).toBe(true);
+
+      // Verify middleware received no authInfo
+      expect(middlewareLog).toHaveLength(2);
+      expect(middlewareLog[0]).toEqual({
+        phase: "before",
+        authInfo: undefined,
+        hasAuthInfo: false,
+      });
+      expect(middlewareLog[1]).toEqual({
+        phase: "after",
+        authInfo: undefined,
+        hasAuthInfo: false,
+      });
+    });
+  });
+
+  describe("Direct server dispatch with authInfo", () => {
+    it("should pass authInfo through _dispatch method", async () => {
+      let capturedAuthInfo: AuthInfo | undefined;
+
+      server.tool("direct-auth-test", {
+        description: "Test tool for direct dispatch with authInfo",
+        handler: (_args, ctx) => {
+          capturedAuthInfo = ctx.authInfo;
+          return {
+            content: [{ type: "text", text: "direct-auth-response" }],
+          };
+        },
+      });
+
+      // Use _dispatch directly with authInfo
+      const result = await server._dispatch(
+        {
+          jsonrpc: "2.0",
+          id: "direct-call",
+          method: "tools/call",
+          params: {
+            name: "direct-auth-test",
+            arguments: {},
+          },
+        },
+        { authInfo: mockAuthInfo },
+      );
+
+      expect(result?.error).toBeUndefined();
+      expect(result?.result).toEqual({
+        content: [{ type: "text", text: "direct-auth-response" }],
+      });
+
+      // Verify authInfo was passed correctly
+      expect(capturedAuthInfo).toEqual(mockAuthInfo);
+    });
+
+    it("should work with _dispatch when authInfo is not provided", async () => {
+      let capturedAuthInfo: AuthInfo | undefined;
+
+      server.tool("direct-no-auth-test", {
+        description: "Test tool for direct dispatch without authInfo",
+        handler: (_args, ctx) => {
+          capturedAuthInfo = ctx.authInfo;
+          return {
+            content: [{ type: "text", text: "direct-no-auth-response" }],
+          };
+        },
+      });
+
+      // Use _dispatch without authInfo
+      const result = await server._dispatch({
+        jsonrpc: "2.0",
+        id: "direct-call",
+        method: "tools/call",
+        params: {
+          name: "direct-no-auth-test",
+          arguments: {},
+        },
+      });
+
+      expect(result?.error).toBeUndefined();
+      expect(result?.result).toEqual({
+        content: [{ type: "text", text: "direct-no-auth-response" }],
+      });
+
+      // Verify authInfo is undefined
+      expect(capturedAuthInfo).toBeUndefined();
+    });
+  });
+
+  describe("AuthInfo data integrity", () => {
+    it("should preserve all authInfo fields correctly", async () => {
+      let capturedAuthInfo: AuthInfo | undefined;
+
+      const complexAuthInfo: AuthInfo = {
+        token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test",
+        scopes: ["read:user", "write:repo", "admin:org"],
+        expiresAt: 1234567890,
+        extra: {
+          userId: "user-456",
+          provider: "oauth2",
+          refreshToken: "refresh-123",
+          metadata: {
+            roles: ["admin", "user"],
+            permissions: { canRead: true, canWrite: true },
+          },
+        },
+      };
+
+      server.tool("complex-auth-test", {
+        description: "Test tool for complex authInfo",
+        handler: (_args, ctx) => {
+          capturedAuthInfo = ctx.authInfo;
+          return {
+            content: [{ type: "text", text: "complex-auth-response" }],
+          };
+        },
+      });
+
+      const result = await server._dispatch(
+        {
+          jsonrpc: "2.0",
+          id: "complex-call",
+          method: "tools/call",
+          params: {
+            name: "complex-auth-test",
+            arguments: {},
+          },
+        },
+        { authInfo: complexAuthInfo },
+      );
+
+      expect(result?.error).toBeUndefined();
+
+      // Verify all fields are preserved correctly
+      expect(capturedAuthInfo).toEqual(complexAuthInfo);
+      expect(capturedAuthInfo?.token).toBe(complexAuthInfo.token);
+      expect(capturedAuthInfo?.scopes).toEqual(complexAuthInfo.scopes);
+      // @ts-expect-error - expiresAt is optional
+      expect(capturedAuthInfo?.expiresAt).toBe(complexAuthInfo.expiresAt);
+      // @ts-expect-error - extra is optional
+      expect(capturedAuthInfo?.extra).toEqual(complexAuthInfo.extra);
+    });
+  });
+
+  describe("Context authInfo consistency", () => {
+    it("should maintain authInfo consistency across request lifecycle", async () => {
+      const capturedAuthInfos: AuthInfo[] = [];
+
+      // Middleware that captures authInfo at different phases
+      server.use(async (ctx, next) => {
+        if (ctx.authInfo) {
+          capturedAuthInfos.push({ ...ctx.authInfo });
+        }
+        await next();
+        if (ctx.authInfo) {
+          capturedAuthInfos.push({ ...ctx.authInfo });
+        }
+      });
+
+      server.tool("consistency-test", {
+        description: "Test authInfo consistency",
+        handler: (_args, ctx) => {
+          if (ctx.authInfo) {
+            capturedAuthInfos.push({ ...ctx.authInfo });
+          }
+          return {
+            content: [{ type: "text", text: "consistency-response" }],
+          };
+        },
+      });
+
+      await server._dispatch(
+        {
+          jsonrpc: "2.0",
+          id: "consistency-call",
+          method: "tools/call",
+          params: {
+            name: "consistency-test",
+            arguments: {},
+          },
+        },
+        { authInfo: mockAuthInfo },
+      );
+
+      // Should have captured authInfo three times (middleware before, handler, middleware after)
+      expect(capturedAuthInfos).toHaveLength(3);
+
+      // All should be identical
+      capturedAuthInfos.forEach((authInfo) => {
+        expect(authInfo).toEqual(mockAuthInfo);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR introduces support for the `AuthInfo` type on the mcp server's context parameter.

This mimics the type in the `@modelcontextprotocol/sdk` package for minimal cognitive overhead if someone swaps packages.

The goal is to allow users of mcp-lite to inject authentication information about the currently logged in user to the tool resourc / prompt handlers. This will be available as `ctx.authInfo`

