### PR TITLE
Replace event store with session store

### DIFF
--- a/.changeset/eleven-moons-search.md
+++ b/.changeset/eleven-moons-search.md
@@ -1,0 +1,5 @@
+---
+"mcp-lite": minor
+---
+
+Breaking change: `eventStore` is replaced by `sessionStore` with a generic `SessionStore` interface that allows for combined MCP session management. Default `InMemorySessionStore` is provided.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -118,6 +118,24 @@ app.all("/mcp", async (c) => {
 });
 ```
 
+## Sessions, SSE, and SessionStore
+
+Streamable HTTP transport supports server-sent events (SSE) for streaming progress and responses. The transport manages per-session state via a SessionStore.
+
+- Default store: `InMemorySessionStore({ maxEventBufferSize: 1024 })`
+- Configure a custom store by passing `sessionStore` to `StreamableHttpTransport`
+- You can also provide `generateSessionId` to control session identifiers
+
+```typescript
+import { StreamableHttpTransport } from "mcp-lite";
+
+// In-memory session store is the default; configure only if you need overrides
+const transport = new StreamableHttpTransport({
+  generateSessionId: () => crypto.randomUUID(),
+});
+
+const httpHandler = transport.bind(mcp);
+```
 ## Tools
 
 ### Basic Tool with JSON Schema

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -10,11 +10,45 @@ export const MCP_LAST_EVENT_ID_HEADER = "Last-Event-ID";
 
 export const SSE_ACCEPT_HEADER = "text/event-stream";
 
-export const NOTIFICATIONS = {
-  TOOLS_LIST_CHANGED: "notifications/tools/list_changed",
-  PROMPTS_LIST_CHANGED: "notifications/prompts/list_changed",
-  RESOURCES_LIST_CHANGED: "notifications/resources/list_changed",
-  PROGRESS: "notifications/progress",
-  INITIALIZED: "notifications/initialized",
-  CANCELLED: "notifications/cancelled",
+export const METHODS = {
+  INITIALIZE: "initialize",
+  PING: "ping",
+  TOOLS: {
+    LIST: "tools/list",
+    CALL: "tools/call",
+  },
+  PROMPTS: {
+    LIST: "prompts/list",
+    GET: "prompts/get",
+  },
+  RESOURCES: {
+    LIST: "resources/list",
+    TEMPLATES_LIST: "resources/templates/list",
+    READ: "resources/read",
+    SUBSCRIBE: "resources/subscribe",
+    UNSUBSCRIBE: "resources/unsubscribe",
+  },
+  NOTIFICATIONS: {
+    CANCELLED: "notifications/cancelled",
+    INITIALIZED: "notifications/initialized",
+    PROGRESS: "notifications/progress",
+    ROOTS: {
+      LIST_CHANGED: "notifications/roots/list_changed",
+    },
+    TOOLS: {
+      LIST_CHANGED: "notifications/tools/list_changed",
+    },
+    PROMPTS: {
+      LIST_CHANGED: "notifications/prompts/list_changed",
+    },
+    RESOURCES: {
+      LIST_CHANGED: "notifications/resources/list_changed",
+    },
+  },
+  LOGGING: {
+    SET_LEVEL: "logging/setLevel",
+  },
+  COMPLETION: {
+    COMPLETE: "completion/complete",
+  },
 } as const;

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -1,5 +1,8 @@
 import type { StandardSchemaV1 } from "@standard-schema/spec";
-import { NOTIFICATIONS, SUPPORTED_MCP_PROTOCOL_VERSION } from "./constants.js";
+import {
+  METHODS,
+  SUPPORTED_MCP_PROTOCOL_VERSION,
+} from "./constants.js";
 import {
   type CreateContextOptions,
   createContext,
@@ -47,7 +50,7 @@ import {
   JSON_RPC_ERROR_CODES,
 } from "./types.js";
 import { compileUriTemplate } from "./uri-template.js";
-import { isObject, isString } from "./utils.js";
+import { errorToResponse, isObject, isString } from "./utils.js";
 import { extractArgumentsFromSchema, resolveToolSchema } from "./validation.js";
 
 async function runMiddlewares(
@@ -68,31 +71,6 @@ async function runMiddlewares(
     }
   };
   await dispatch(0);
-}
-
-function errorToResponse(
-  err: unknown,
-  requestId: JsonRpcId | undefined,
-): JsonRpcRes | null {
-  if (requestId === undefined) {
-    return null;
-  }
-
-  if (err instanceof RpcError) {
-    return createJsonRpcError(requestId, err.toJson());
-  }
-
-  const errorData =
-    err instanceof Error ? { message: err.message, stack: err.stack } : err;
-
-  return createJsonRpcError(
-    requestId,
-    new RpcError(
-      JSON_RPC_ERROR_CODES.INTERNAL_ERROR,
-      "Internal error",
-      errorData,
-    ).toJson(),
-  );
 }
 
 // progress token extraction now lives in context.ts
@@ -272,25 +250,28 @@ export class McpServer {
     this.schemaAdapter = options.schemaAdapter;
 
     this.methods = {
-      initialize: this.handleInitialize.bind(this),
-      ping: this.handlePing.bind(this),
-      "tools/list": this.handleToolsList.bind(this),
-      "tools/call": this.handleToolsCall.bind(this),
-      "prompts/list": this.handlePromptsList.bind(this),
-      "prompts/get": this.handlePromptsGet.bind(this),
-      "resources/list": this.handleResourcesList.bind(this),
-      "resources/templates/list": this.handleResourceTemplatesList.bind(this),
-      "resources/read": this.handleResourcesRead.bind(this),
-      "resources/subscribe": this.handleNotImplemented.bind(this),
-      "notifications/cancelled": this.handleNotificationCancelled.bind(this),
-      "notifications/initialized":
+      [METHODS.INITIALIZE]: this.handleInitialize.bind(this),
+      [METHODS.PING]: this.handlePing.bind(this),
+      [METHODS.TOOLS.LIST]: this.handleToolsList.bind(this),
+      [METHODS.TOOLS.CALL]: this.handleToolsCall.bind(this),
+      [METHODS.PROMPTS.LIST]: this.handlePromptsList.bind(this),
+      [METHODS.PROMPTS.GET]: this.handlePromptsGet.bind(this),
+      [METHODS.RESOURCES.LIST]: this.handleResourcesList.bind(this),
+      [METHODS.RESOURCES.TEMPLATES_LIST]:
+        this.handleResourceTemplatesList.bind(this),
+      [METHODS.RESOURCES.READ]: this.handleResourcesRead.bind(this),
+      [METHODS.RESOURCES.SUBSCRIBE]: this.handleNotImplemented.bind(this),
+      [METHODS.NOTIFICATIONS.CANCELLED]:
+        this.handleNotificationCancelled.bind(this),
+      [METHODS.NOTIFICATIONS.INITIALIZED]:
         this.handleNotificationInitialized.bind(this),
-      "notifications/progress": this.handleNotificationProgress.bind(this),
-      "notifications/roots/list_changed":
+      [METHODS.NOTIFICATIONS.PROGRESS]:
+        this.handleNotificationProgress.bind(this),
+      [METHODS.NOTIFICATIONS.ROOTS.LIST_CHANGED]:
         this.handleNotificationRootsListChanged.bind(this),
-      "logging/setLevel": this.handleLoggingSetLevel.bind(this),
-      "resources/unsubscribe": this.handleNotImplemented.bind(this),
-      "completion/complete": this.handleNotImplemented.bind(this),
+      [METHODS.LOGGING.SET_LEVEL]: this.handleLoggingSetLevel.bind(this),
+      [METHODS.RESOURCES.UNSUBSCRIBE]: this.handleNotImplemented.bind(this),
+      [METHODS.COMPLETION.COMPLETE]: this.handleNotImplemented.bind(this),
     };
   }
 
@@ -474,7 +455,7 @@ export class McpServer {
     this.tools.set(name, entry);
     if (this.initialized) {
       this.notificationSender?.(undefined, {
-        method: NOTIFICATIONS.TOOLS_LIST_CHANGED,
+        method: METHODS.NOTIFICATIONS.TOOLS.LIST_CHANGED,
       });
     }
     return this;
@@ -588,7 +569,7 @@ export class McpServer {
     this.resources.set(template, entry);
     if (this.initialized) {
       this.notificationSender?.(undefined, {
-        method: NOTIFICATIONS.RESOURCES_LIST_CHANGED,
+        method: METHODS.NOTIFICATIONS.RESOURCES.LIST_CHANGED,
       });
     }
     return this;
@@ -694,7 +675,7 @@ export class McpServer {
 
     if (this.initialized) {
       this.notificationSender?.(undefined, {
-        method: NOTIFICATIONS.PROMPTS_LIST_CHANGED,
+        method: METHODS.NOTIFICATIONS.PROMPTS.LIST_CHANGED,
       });
     }
 
@@ -731,7 +712,7 @@ export class McpServer {
             this.notificationSender?.(
               sessionId,
               {
-                method: NOTIFICATIONS.PROGRESS,
+                method: METHODS.NOTIFICATIONS.PROGRESS,
                 params: {
                   progressToken,
                   ...(update as Record<string, unknown>),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,10 +12,10 @@ export {
 } from "./sse-writer.js";
 export {
   type EventId,
-  type EventStore,
-  InMemoryEventStore,
   type SessionId,
   type SessionMeta,
+  type SessionStore,
+  InMemorySessionStore,
 } from "./store.js";
 export {
   StreamableHttpTransport,

--- a/packages/core/src/transport-http.ts
+++ b/packages/core/src/transport-http.ts
@@ -4,7 +4,7 @@ import {
   MCP_LAST_EVENT_ID_HEADER,
   MCP_PROTOCOL_HEADER,
   MCP_SESSION_ID_HEADER,
-  NOTIFICATIONS,
+  METHODS,
   SSE_ACCEPT_HEADER,
   SUPPORTED_MCP_PROTOCOL_VERSION,
 } from "./constants.js";
@@ -147,9 +147,9 @@ export class StreamableHttpTransport {
           return;
         }
         const allowedCrossSessionNotifications = [
-          NOTIFICATIONS.TOOLS_LIST_CHANGED,
-          NOTIFICATIONS.PROMPTS_LIST_CHANGED,
-          NOTIFICATIONS.RESOURCES_LIST_CHANGED,
+          METHODS.NOTIFICATIONS.TOOLS.LIST_CHANGED,
+          METHODS.NOTIFICATIONS.PROMPTS.LIST_CHANGED,
+          METHODS.NOTIFICATIONS.RESOURCES.LIST_CHANGED,
         ];
 
         // No session: allow safe broadcast for list_changed notifications to all session streams

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,3 +1,11 @@
+import { RpcError } from "./errors";
+import {
+  createJsonRpcError,
+  JSON_RPC_ERROR_CODES,
+  type JsonRpcId,
+  type JsonRpcRes,
+} from "./types";
+
 /**
  * Checks if a value is an object.
  * @param value - The value to check.
@@ -76,4 +84,29 @@ export function isString(value: unknown): value is string {
 
 export function isNumber(value: unknown): value is number {
   return typeof value === "number";
+}
+
+export function errorToResponse(
+  err: unknown,
+  requestId: JsonRpcId | undefined,
+): JsonRpcRes | null {
+  if (requestId === undefined) {
+    return null;
+  }
+
+  if (err instanceof RpcError) {
+    return createJsonRpcError(requestId, err.toJson());
+  }
+
+  const errorData =
+    err instanceof Error ? { message: err.message, stack: err.stack } : err;
+
+  return createJsonRpcError(
+    requestId,
+    new RpcError(
+      JSON_RPC_ERROR_CODES.INTERNAL_ERROR,
+      "Internal error",
+      errorData,
+    ).toJson(),
+  );
 }

--- a/packages/core/tests/integration/http-request-sse.test.ts
+++ b/packages/core/tests/integration/http-request-sse.test.ts
@@ -7,16 +7,16 @@ import {
   openRequestStream,
   type TestServer,
 } from "@internal/test-utils";
-import { InMemoryEventStore, McpServer } from "../../src/index.js";
+import { InMemorySessionStore, McpServer } from "../../src/index.js";
 
 describe("Per-request SSE", () => {
   let testServer: TestServer;
   let mcpServer: McpServer;
-  let eventStore: InMemoryEventStore;
+  let sessionStore: InMemorySessionStore;
   const fixedSessionId = "test-session-456";
 
   beforeEach(async () => {
-    eventStore = new InMemoryEventStore();
+    sessionStore = new InMemorySessionStore({ maxEventBufferSize: 1024 });
     mcpServer = new McpServer({ name: "test-server", version: "1.0.0" });
 
     // Add tool that emits progress updates when progressToken is present
@@ -41,7 +41,7 @@ describe("Per-request SSE", () => {
 
     testServer = await createTestHarness(mcpServer, {
       sessionId: fixedSessionId,
-      eventStore,
+      sessionStore,
     });
   });
 

--- a/packages/core/tests/integration/http-session-sse.test.ts
+++ b/packages/core/tests/integration/http-session-sse.test.ts
@@ -8,16 +8,16 @@ import {
   openSessionStream,
   type TestServer,
 } from "@internal/test-utils";
-import { InMemoryEventStore, McpServer } from "../../src/index.js";
+import { InMemorySessionStore, McpServer } from "../../src/index.js";
 
 describe("Session SSE Happy Path", () => {
   let testServer: TestServer;
   let mcpServer: McpServer;
-  let eventStore: InMemoryEventStore;
+  let sessionStore: InMemorySessionStore;
   const fixedSessionId = "test-session-123";
 
   beforeEach(async () => {
-    eventStore = new InMemoryEventStore();
+    sessionStore = new InMemorySessionStore({ maxEventBufferSize: 1024 });
     mcpServer = new McpServer({ name: "test-server", version: "1.0.0" });
 
     // Add tool that emits progress updates when progressToken is present
@@ -42,7 +42,7 @@ describe("Session SSE Happy Path", () => {
 
     testServer = await createTestHarness(mcpServer, {
       sessionId: fixedSessionId,
-      eventStore,
+      sessionStore,
     });
   });
 

--- a/packages/test-utils/src/sse.ts
+++ b/packages/test-utils/src/sse.ts
@@ -76,7 +76,7 @@ export async function collectSseEvents(
       events.push(event);
     }
   } catch (error) {
-    if (controller.signal && controller.signal.aborted) {
+    if (controller.signal?.aborted) {
       // Timeout occurred - return events collected so far
       return events;
     }
@@ -107,7 +107,7 @@ export async function collectSseEventsCount(
       }
     }
   } catch (error) {
-    if (controller.signal && controller.signal.aborted) {
+    if (controller.signal?.aborted) {
       // Timeout occurred - return events collected so far
       return events;
     }


### PR DESCRIPTION

Breaking change: this replaces the `EventStore` with a more general `SessionStore` interface.

This allows for more flexibility in session management in environments where default in-memory session storage is not sufficient. The features for replaying events remain the same.
